### PR TITLE
[14] Fix test coverage

### DIFF
--- a/yaaf.gemspec
+++ b/yaaf.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'reek', '~> 5.6.0'
   spec.add_development_dependency 'rspec', '~> 3.9.0'
   spec.add_development_dependency 'rubocop', '~> 0.80.0'
-  spec.add_development_dependency 'simplecov', '~> 0.18.5'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'sqlite3', '~> 1.4.2'
 end


### PR DESCRIPTION
Given Code Climate does not support 0.18.X versions of simplecov, we are downgrading to 0.17.1