### PR TITLE
Fix gemspec

### DIFF
--- a/yaaf.gemspec
+++ b/yaaf.gemspec
@@ -3,9 +3,9 @@
 require_relative 'lib/yaaf/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'YAAF'
+  spec.name          = 'yaaf'
   spec.version       = YAAF::VERSION
-  spec.authors       = ['Juan Manuel Ramallo']
+  spec.authors       = ['Juan Manuel Ramallo', 'Santiago Bartesaghi']
   spec.email         = ['juan.ramallo@rootstrap.com']
 
   spec.summary       = 'Easing the form object pattern in Rails applications.'


### PR DESCRIPTION
The name of the gem needs to match the name of main file. Otherwise, bundler won't find any file to require when executing "Bundler.require(*Rails.groups)" causing the app to fail due to NameError.

A workaround was to add the attribute "require: 'yaaf'" to the Gemfile, but that's not a common thing to do, which was done here https://github.com/rootstrap/yaaf-examples/blob/master/Gemfile#L17. So after this PR is merged we'll be able to update that line to look like:

```ruby
gem 'yaaf', github: 'rootstrap/yaaf'
```