### PR TITLE
Adapt errors for active admin

### DIFF
--- a/lib/yaaf.rb
+++ b/lib/yaaf.rb
@@ -4,6 +4,7 @@ require 'active_model'
 require 'active_record'
 require 'yaaf/form'
 require 'yaaf/version'
+require 'yaaf/active_admin'
 
 # Namespace for all objects in YAAF
 module YAAF

--- a/lib/yaaf/active_admin.rb
+++ b/lib/yaaf/active_admin.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module YAAF
+  module ActiveAdmin
+    extend ActiveSupport::Concern
+
+    included do
+      after_validation :sanitize_errors
+
+      delegate_missing_to :main_model
+
+      def self.reflect_on_association(*args)
+        main_model_class.reflect_on_association(*args)
+      end
+
+      private
+
+      def sanitize_errors
+        form_attributes_validations = self.class.validators.map(&:attributes).flatten
+        form_attributes_validations.each do |form_attributes_validation|
+          message = errors.messages[form_attributes_validation]
+          errors.add(:base, message) if message.present?
+        end
+      end
+
+      def main_model
+        models.first
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Adapt errors for Active Admin

These changes try to solve #43.

The form object validations' errors are loaded to the `:base` key, so when adding `f.semantic_errors` to the active admin form it will display them.
Maybe it's worth a discussion if this is useful for the users or not. Let me know what you think.
In my experience, I had to manage the errors in the admin, with some if's and showing them with flash. This solution is simpler I think but maybe it doesn't worth it to add this changes since the users have to add some things on their end.

Thanks to @santib for all the help 🙌 .

For this to work correctly the user will have to add some changes.

- Add `include ::YAAF::ActiveAdmin` to the form object.
- The addition of `f.semantic_errors` to the form object.
- The definition of `self.main_model_class` in the form object, with the class of the model of the active admin view:

```ruby
def self.main_model_class
  ModelClass
end
```
- The assignment of the resource with the form object when it fails so the errors are displayed:

```ruby
if form_object.save
  redirect_to admin_model_path(id: params[:id])
else
  @resource = form_object
  render action: :new
end
```
- The `accepts_nested_attributes_for` in the model is still needed, as active admin depends on it.

## To do:

- [ ] Add explanation in Readme to let users know what they have to add in their end.
- [ ] Add tests.
- [ ] Add an example that uses this.