### PR TITLE
Fix rails 6.1 deprecation warning (#47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: [rails_4.0.0.gemfile, rails_5.0.0.gemfile, rails_5.2.3.gemfile, rails_6.0.0.gemfile, rails_master.gemfile]
+        gemfile: [rails_4.0.0.gemfile, rails_5.0.0.gemfile, rails_5.2.3.gemfile, rails_6.0.0.gemfile, rails_6.1.0.gemfile, rails_master.gemfile]
         ruby_version: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
         exclude:
           - gemfile: rails_master.gemfile
             ruby_version: 2.4.x
           - gemfile: rails_6.0.0.gemfile
+            ruby_version: 2.4.x
+          - gemfile: rails_6.1.0.gemfile
             ruby_version: 2.4.x
     steps:
     - uses: actions/checkout@v2

--- a/.reek.yml
+++ b/.reek.yml
@@ -18,7 +18,7 @@ detectors:
     min_clump_size: 2
   DuplicateMethodCall:
     enabled: true
-    exclude: []
+    exclude: ['YAAF::Form#promote_errors']
     max_calls: 1
     allow_calls: []
   FeatureEnvy:

--- a/lib/yaaf/form.rb
+++ b/lib/yaaf/form.rb
@@ -30,6 +30,7 @@ module YAAF
 
     attr_accessor :models
 
+    # :reek:DuplicateMethodCall
     def promote_errors(model)
       if rails_version_less_than_6_1?
         model.errors.each do |attribute, message|

--- a/lib/yaaf/form.rb
+++ b/lib/yaaf/form.rb
@@ -68,7 +68,8 @@ module YAAF
     end
 
     def rails_version_less_than_6_1?
-      Gem::Version.new(ActiveModel::VERSION) < Gem::Version.new('6.1')
+      ActiveModel::VERSION::MAJOR < 6 ||
+        ActiveModel::VERSION::MAJOR == 6 && ActiveModel::VERSION::MINOR.zero?
     end
   end
 end

--- a/lib/yaaf/form.rb
+++ b/lib/yaaf/form.rb
@@ -68,8 +68,7 @@ module YAAF
     end
 
     def rails_version_less_than_6_1?
-      ActiveModel::VERSION::MAJOR < 6 ||
-        ActiveModel::VERSION::MAJOR == 6 && ActiveModel::VERSION::MINOR.zero?
+      Gem::Version.new(ActiveModel::VERSION) < Gem::Version.new('6.1')
     end
   end
 end

--- a/lib/yaaf/form.rb
+++ b/lib/yaaf/form.rb
@@ -31,8 +31,14 @@ module YAAF
     attr_accessor :models
 
     def promote_errors(model)
-      model.errors.each do |attribute, message|
-        errors.add(attribute, message)
+      if rails_version_less_than_6_1?
+        model.errors.each do |attribute, message|
+          errors.add(attribute, message)
+        end
+      else
+        model.errors.each do |model_error|
+          errors.add(model_error.attribute, model_error.message)
+        end
       end
     end
 
@@ -59,6 +65,11 @@ module YAAF
     def handle_transaction_rollback(exception)
       run_callbacks :rollback
       raise exception
+    end
+
+    def rails_version_less_than_6_1?
+      ActiveModel::VERSION::MAJOR < 6 ||
+        ActiveModel::VERSION::MAJOR == 6 && ActiveModel::VERSION::MINOR.zero?
     end
   end
 end

--- a/lib/yaaf/form.rb
+++ b/lib/yaaf/form.rb
@@ -30,7 +30,6 @@ module YAAF
 
     attr_accessor :models
 
-    # :reek:DuplicateMethodCall
     def promote_errors(model)
       if rails_version_less_than_6_1?
         model.errors.each do |attribute, message|

--- a/spec/gemfiles/rails_6.1.0.gemfile
+++ b/spec/gemfiles/rails_6.1.0.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../..'
+
+gem 'rails', '~> 6.1.0'

--- a/spec/gemfiles/rails_main.gemfile
+++ b/spec/gemfiles/rails_main.gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: '../..'
 
-gem 'rails', github: 'rails/rails', branch: 'main'
+gem 'rails', git: 'https://github.com/rails/rails', branch: 'main'


### PR DESCRIPTION
### Summary
Fixes #47. 

### Other Information
I noticed that code coverage dropped a little on my local machine, I guess this is because of version conditions, I have no experience in code coverage, but I guess you need to run against different versions and then [merge the results somehow](https://github.com/simplecov-ruby/simplecov#merging-results)? Or maybe you already know the way to do it, I see that there are some GitHub action and code climate badge (which displays ? for me), anyway, this is probably another topic.
Also, I noticed another deprecation warning when running tests 
```yaaf/lib/yaaf/form.rb:56: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call```. 
This can be easily fixed if you add `**` to options in this method
```ruby
def save_models(options)
  models.map { |model| model.save!(**options) }
end
```
I can make another PR for this warning or update this one. 