### PR TITLE
Change promote errors

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -18,12 +18,12 @@ detectors:
     min_clump_size: 2
   DuplicateMethodCall:
     enabled: true
-    exclude: ['YAAF::Form#promote_errors']
+    exclude: []
     max_calls: 1
     allow_calls: []
   FeatureEnvy:
     enabled: true
-    exclude: []
+    exclude: ['YAAF::Form#promote_legacy_errors']
   InstanceVariableAssumption:
     enabled: false
   IrresponsibleModule:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you want to learn more about Form Objects you can check out [these great arti
 
 ### Why YAAF?
 
-- It is [64 lines long](https://github.com/rootstrap/yaaf/blob/master/lib/yaaf/form.rb#L64). As you can imagine, we did no magic in such a few lines of code, we just leveraged Rails modules in order to provide our form objects with a Rails-like behavior. You can review the code, it's easy to understand.
+- It is [83 lines long](https://github.com/rootstrap/yaaf/blob/master/lib/yaaf/form.rb#L83). As you can imagine, we did no magic in such a few lines of code, we just leveraged Rails modules in order to provide our form objects with a Rails-like behavior. You can review the code, it's easy to understand.
 
 - It provides a similar API to `ActiveModel` models so you can treat them interchangeably.
 

--- a/lib/yaaf/form.rb
+++ b/lib/yaaf/form.rb
@@ -32,12 +32,20 @@ module YAAF
 
     def promote_errors(model)
       if rails_version_less_than_6_1?
-        model.errors.each do |attribute, message|
-          errors.add(attribute, message)
-        end
+        promote_legacy_errors(model)
       else
         model.errors.each do |model_error|
-          errors.add(model_error.attribute, model_error.message)
+          errors.add(model_error.attribute, model_error.type, **model_error.options)
+        end
+      end
+    end
+
+    def promote_legacy_errors(model)
+      model.errors.details.each do |attribute, details|
+        details.each do |detail|
+          options = detail.except(:error)
+
+          errors.add(attribute, detail[:error], **options)
         end
       end
     end


### PR DESCRIPTION
### Summary

I noticed that when promoting an error from a model to the form, a little bit of information and functionality was lost.
Example:
```ruby
class User < ApplicationRecord
  validates :name, presence: true
end

class UserForm < YAAF::Form
  attr_accessor :name

  def initialize(attributes)
    super(attributes)
    @models = [user]
  end

  def user
    @user ||= User.new(name: name)
  end
end

# Before
form = UserForm.new(name: '')
form.valid? # => false
form.errors.added?(:name, :blank) # => false
form.errors
# => #<ActiveModel::Errors:0x0000559d517137e0
# @base=#<UserForm:0x00007f2c60b07730...>,
# @details={:name=>[{:error=>"can't be blank"}]},
# @messages={:name=>["can't be blank"]}>

# After
form = UserForm.new(name: '')
form.valid? # => false
form.errors.added?(:name, :blank) # => true
form.errors
# => #<ActiveModel::Errors:0x00007f2c60c23d08
# @base=#<UserForm:0x0000559d4fb59680...>,
# @details={:name=>[{:error=>:blank}]},
# @messages={:name=>["can't be blank"]}>
```

### Other Information

I ran RSpec and all tests passed. But when running `rake code_analysis` one of the `reek` checks gives a warning.
```
FeatureEnvy: YAAF::Form#promote_legacy_errors refers to 'detail' more than self (maybe move it to another class?) [https://github.com/troessner/reek/blob/v5.6.0/docs/Feature-Envy.md]
```

I don't think it makes sense to move this logic to another class as you advise. I change the Reek configuration and exclude this warning.