### PR TITLE
Drop support for older versions of Rails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: [rails_4.0.0.gemfile, rails_5.0.0.gemfile, rails_5.2.3.gemfile, rails_6.0.0.gemfile, rails_6.1.0.gemfile, rails_main.gemfile]
-        ruby_version: [2.4, 2.5, 2.6, 2.7]
+        gemfile: [rails_5.2.0.gemfile, rails_6.0.0.gemfile, rails_6.1.0.gemfile, rails_main.gemfile]
+        ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7]
         exclude:
+          - gemfile: rails_main.gemfile
+            ruby_version: 2.3
           - gemfile: rails_main.gemfile
             ruby_version: 2.4
           - gemfile: rails_main.gemfile
@@ -18,7 +20,11 @@ jobs:
           - gemfile: rails_main.gemfile
             ruby_version: 2.6
           - gemfile: rails_6.0.0.gemfile
+            ruby_version: 2.3
+          - gemfile: rails_6.0.0.gemfile
             ruby_version: 2.4
+          - gemfile: rails_6.1.0.gemfile
+            ruby_version: 2.3
           - gemfile: rails_6.1.0.gemfile
             ruby_version: 2.4
     env:

--- a/spec/gemfiles/rails_4.0.0.gemfile
+++ b/spec/gemfiles/rails_4.0.0.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../..'
-
-gem 'rails', '~> 4.0.0'
-gem 'sqlite3', '~> 1.3.6'

--- a/spec/gemfiles/rails_5.2.0.gemfile
+++ b/spec/gemfiles/rails_5.2.0.gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: '../..'
 
-gem 'rails', '~> 5.0.0'
+gem 'rails', '~> 5.2.0'

--- a/spec/gemfiles/rails_5.2.3.gemfile
+++ b/spec/gemfiles/rails_5.2.3.gemfile
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../..'
-
-gem 'rails', '~> 5.2.3'

--- a/yaaf.gemspec
+++ b/yaaf.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir['LICENSE.txt', 'README.md', 'lib/**/*']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activemodel', ['>= 4', '< 7']
-  spec.add_dependency 'activerecord', ['>= 4', '< 7']
+  spec.add_dependency 'activemodel', ['>= 5.2', '< 7']
+  spec.add_dependency 'activerecord', ['>= 5.2', '< 7']
 
   spec.add_development_dependency 'database_cleaner-active_record', '~> 1.8.0'
   spec.add_development_dependency 'rake', '~> 13.0.1'


### PR DESCRIPTION
We recently merged https://github.com/rootstrap/yaaf/pull/56 which breaks in Rails < 5.2. So let's drop support for those older versions.

Other options would be to do an `if` and support older versions but not sure if it's worth it. Rails 5.2 was released in 2018 so it's pretty old already.

Seems like Rails is no longer supporting 5.1 https://guides.rubyonrails.org/maintenance_policy.html