### PR TITLE
Enable caching for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+        bundler-cache: true
     - name: Before build
       run: |
         sudo apt-get install libsqlite3-dev
@@ -47,9 +48,8 @@ jobs:
         ./cc-test-reporter before-build
       env:
         CC_TEST_REPORTER_ID: aff2c7b9e07e54d5fc9e5588d2e2a8bab4f69950d35000edc2b6250bbaba477d
-    - name: Build and test
+    - name: Run test
       run: |
-        bundle install --gemfile spec/gemfiles/${{ matrix.gemfile }} --jobs 4 --retry 3
         bundle exec rake code_analysis
         bundle exec rspec
     - name: Report to CodeClimate


### PR DESCRIPTION
### Summary

I saw the Add cache to CI task on the project board, so I added it. Please merge it if you like.
https://github.com/rootstrap/yaaf/projects/1

### Other Information

For an explanation of bundler-cache, click here.
https://github.com/ruby/setup-ruby#caching-bundle-install-automatically
