### PR TITLE
Set CC_TEST_REPORTER as secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         chmod +x ./cc-test-reporter
         ./cc-test-reporter before-build
       env:
-        CC_TEST_REPORTER_ID: aff2c7b9e07e54d5fc9e5588d2e2a8bab4f69950d35000edc2b6250bbaba477d
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
     - name: Run test
       run: |
         bundle exec rake code_analysis
@@ -64,4 +64,4 @@ jobs:
       run: |
         ./cc-test-reporter after-build --exit-code 0
       env:
-        CC_TEST_REPORTER_ID: aff2c7b9e07e54d5fc9e5588d2e2a8bab4f69950d35000edc2b6250bbaba477d
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}


### PR DESCRIPTION
### Summary

Set CC_TEST_REPORTER as a secret, as it is sensitive information.


### Notes

In order to merge this, we should first set the variable in Settings
