### PR TITLE
Use ruby-3.0.3 because Rails 7 is not yet ready for ruby-3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         gemfile: [rails_5_2.gemfile, rails_6_0.gemfile, rails_6_1.gemfile, rails_7_0.gemfile, rails_main.gemfile]
-        ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0.3]
         exclude:
           - gemfile: rails_main.gemfile
             ruby_version: 2.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
           - gemfile: rails_6_0.gemfile
             ruby_version: 2.4
           - gemfile: rails_6_0.gemfile
-            ruby_version: 3.0
+            ruby_version: 3.0.3
           - gemfile: rails_5_2.gemfile
-            ruby_version: 3.0
+            ruby_version: 3.0.3
     env:
       BUNDLE_GEMFILE: spec/gemfiles/${{ matrix.gemfile }}
     steps:


### PR DESCRIPTION
### Summary
Use ruby-3.0.3 because Rails 7 is not yet ready for ruby-3.1
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- ### Other Information -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.
Thanks for contributing to this project! -->
