### PR TITLE
Support ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
             ruby_version: '2.5'
           - gemfile: rails_main.gemfile
             ruby_version: '2.6'
+          - gemfile: rails_main.gemfile
+            ruby_version: '2.7'
           - gemfile: rails_7_0.gemfile
             ruby_version: '2.3'
           - gemfile: rails_7_0.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,36 +9,42 @@ jobs:
     strategy:
       matrix:
         gemfile: [rails_5_2.gemfile, rails_6_0.gemfile, rails_6_1.gemfile, rails_7_0.gemfile, rails_main.gemfile]
-        ruby_version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0.3]
+        ruby_version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
         exclude:
           - gemfile: rails_main.gemfile
-            ruby_version: 2.3
+            ruby_version: '2.3'
           - gemfile: rails_main.gemfile
-            ruby_version: 2.4
+            ruby_version: '2.4'
           - gemfile: rails_main.gemfile
-            ruby_version: 2.5
+            ruby_version: '2.5'
           - gemfile: rails_main.gemfile
-            ruby_version: 2.6
+            ruby_version: '2.6'
           - gemfile: rails_7_0.gemfile
-            ruby_version: 2.3
+            ruby_version: '2.3'
           - gemfile: rails_7_0.gemfile
-            ruby_version: 2.4
+            ruby_version: '2.4'
           - gemfile: rails_7_0.gemfile
-            ruby_version: 2.5
+            ruby_version: '2.5'
           - gemfile: rails_7_0.gemfile
-            ruby_version: 2.6
+            ruby_version: '2.6'
           - gemfile: rails_6_1.gemfile
-            ruby_version: 2.3
+            ruby_version: '2.3'
           - gemfile: rails_6_1.gemfile
-            ruby_version: 2.4
+            ruby_version: '2.4'
           - gemfile: rails_6_0.gemfile
-            ruby_version: 2.3
+            ruby_version: '2.3'
           - gemfile: rails_6_0.gemfile
-            ruby_version: 2.4
+            ruby_version: '2.4'
           - gemfile: rails_6_0.gemfile
-            ruby_version: 3.0.3
+            ruby_version: '3.0'
           - gemfile: rails_5_2.gemfile
-            ruby_version: 3.0.3
+            ruby_version: '3.0'
+          - gemfile: rails_6_1.gemfile
+            ruby_version: '3.1'
+          - gemfile: rails_6_0.gemfile
+            ruby_version: '3.1'
+          - gemfile: rails_5_2.gemfile
+            ruby_version: '3.1'
     env:
       BUNDLE_GEMFILE: spec/gemfiles/${{ matrix.gemfile }}
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
+Layout/BlockAlignment:
+  # Rubocop had a bug in ruby3.1 and this is a workaround to fix it.
+  # 1.22.3 and above are fixed, but must be 1.2 or lower for ruby 2.4 support
+  Enabled: false
+
 Layout/LineLength:
   Max: 100
   # To make it possible to copy or click on URIs in the code, we allow lines


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

- Since ruby 3.1 is now supported in rails7, I have added support for test cases.
  ref. https://github.com/rootstrap/yaaf/pull/80
- I have added a rubocop configuration related to this, and can upgrade if you are willing to cut off support for ruby, which is EOL. Please let me know if this is necessary.


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.
Thanks for contributing to this project! -->

-  have confirmed that the test for the master matrix in rails is failing. This is because DatabaseCleaner is not compatible with Rails changes. The PR has been created, but it is not clear if it will be merged.

https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/75

I have decided that there is no problem with the merge. However, if you wish to remove the edges from the test cases or fork the library temporarily, I will be happy to accommodate you.
