### PR TITLE
Fix CI for Rails 7.1

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'yaaf'
 load File.dirname(__FILE__) + '/support/schema.rb'
 require File.dirname(__FILE__) + '/support/models.rb'
 require File.dirname(__FILE__) + '/support/forms.rb'
+require File.dirname(__FILE__) + '/support/database_cleaner_monkeypatch.rb'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/database_cleaner_monkeypatch.rb
+++ b/spec/support/database_cleaner_monkeypatch.rb
@@ -1,0 +1,13 @@
+module DatabaseCleaner
+  module ActiveRecord
+    class Base < DatabaseCleaner::Strategy
+      def self.migration_table_name
+        if Gem::Version.new('6.0.0') <= ::ActiveRecord.version
+          ::ActiveRecord::Base.connection.schema_migration.table_name
+        else
+          ::ActiveRecord::SchemaMigration.table_name
+        end
+      end
+    end
+  end
+end

--- a/yaaf.gemspec
+++ b/yaaf.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'yaaf'
   spec.version       = YAAF::VERSION
   spec.authors       = ['Juan Manuel Ramallo', 'Santiago Bartesaghi']
-  spec.email         = ['juan.ramallo@rootstrap.com']
+  spec.email         = ['juanmanuelramallo@hey.com', 'santib@hey.com']
 
   spec.summary       = 'Easing the form object pattern in Rails applications.'
   spec.homepage      = 'https://github.com/rootstrap/yaaf'
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activemodel', '>= 5.2'
   spec.add_dependency 'activerecord', '>= 5.2'
 
-  spec.add_development_dependency 'database_cleaner-active_record', '~> 1.8.0'
+  spec.add_development_dependency 'database_cleaner-active_record', '~> 2.0.1'
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'reek', '~> 5.6.0'
   spec.add_development_dependency 'rspec', '~> 3.9.0'


### PR DESCRIPTION
In #82 we added to the CI matrix Rails 7.1 which fails because of database cleaner. Here we monkeypatch database cleaner in test env so we have the CI green.