### PR TITLE
Don't fail if model doesn't respond to marked for destruction

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -23,7 +23,7 @@ detectors:
     allow_calls: []
   FeatureEnvy:
     enabled: true
-    exclude: 
+    exclude:
       - 'YAAF::Form#promote_legacy_errors'
       - 'YAAF::Form#save_models'
   InstanceVariableAssumption:
@@ -44,7 +44,8 @@ detectors:
     max_params: 3
   ManualDispatch:
     enabled: true
-    exclude: []
+    exclude:
+      - 'YAAF::Form#save_models'
   MissingSafeMethod:
     enabled: false
     exclude: []

--- a/lib/yaaf/form.rb
+++ b/lib/yaaf/form.rb
@@ -53,7 +53,11 @@ module YAAF
       options.merge!(validate: false)
 
       models.map do |model|
-        model.marked_for_destruction? ? model.destroy! : model.save!(**options)
+        if model.respond_to?(:marked_for_destruction?) && model.marked_for_destruction?
+          model.destroy!
+        else
+          model.save!(**options)
+        end
       end
     end
 


### PR DESCRIPTION
In case of nested form objects `marked_for_destruction?` is not defined, but we don't want it to fail.